### PR TITLE
Implement soft constraints feature for linear inequality constraints

### DIFF
--- a/example/soft_constraints_v2.py
+++ b/example/soft_constraints_v2.py
@@ -27,7 +27,7 @@ sys.path.append(project_root)
 sys.path.append(src_path)
 
 # Local application imports
-from optimization import MeanVariance, Objective
+from optimization import Optimization, MeanVariance, Objective
 from covariance import Covariance
 from mean_estimation import MeanEstimator
 from constraints import Constraints
@@ -43,7 +43,15 @@ from constraints import Constraints
 def load_data_msci(path: str = None, n: int = 24) -> dict[str, pd.DataFrame]:
     '''Loads MSCI daily returns data from 1999-01-01 to 2023-04-18'''
 
-    path = os.path.join(os.getcwd(), f'data{os.sep}') if path is None else path
+    if path is None:
+        # Get the project root directory (parent of the script's directory)
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(script_dir)
+        path = os.path.join(project_root, 'data')
+    
+    # Ensure path ends with separator
+    if not path.endswith(os.sep):
+        path = path + os.sep
 
     # Load msci country index return series
     df = pd.read_csv(os.path.join(path, 'msci_country_indices.csv'),
@@ -65,7 +73,7 @@ def load_data_msci(path: str = None, n: int = 24) -> dict[str, pd.DataFrame]:
 
 
 
-def solve_gurobi(optimization) -> bool:
+def solve_gurobi(optimization: Optimization) -> bool:
 
     optimization.model.optimize()
     status = optimization.model.status
@@ -81,14 +89,50 @@ def solve_gurobi(optimization) -> bool:
             for i in range(len(optimization.model.x[0:N]))
         }
         obj_val = optimization.model.objVal
+        
+        # Extract slack variable values for soft constraints
+        relaxed_constraints = {}
+        if hasattr(optimization, 'slack_var') and optimization.slack_var is not None:
+            slack_values = optimization.slack_var.X  # Get slack variable values
+            soft_indices = optimization.soft_indices
+            normalization_factors = optimization.normalization_factors
+            
+            # Get constraint names from the linear constraints
+            if optimization.constraints.linear['Amat'] is not None:
+                constraint_names = optimization.constraints.linear['Amat'].index.tolist()
+                
+                # Map soft indices to constraint information
+                for i, (slack_idx, norm_factor) in enumerate(zip(soft_indices, normalization_factors)):
+                    slack_val = slack_values[i]
+                    if slack_val > 1e-6:  # Only report constraints that were actually relaxed
+                        linear_ineq_count = 0
+                        constraint_name = None
+                        for j, (name, sense) in enumerate(zip(constraint_names, optimization.constraints.linear['sense'])):
+                            if sense in ['<=', '>=']:
+                                if linear_ineq_count == slack_idx:
+                                    constraint_name = name
+                                    break
+                                linear_ineq_count += 1
+                        
+                        if constraint_name is None:
+                            constraint_name = f"constraint_{slack_idx}"
+                        
+                        relaxed_constraints[constraint_name] = {
+                            'slack_value': slack_val,
+                            'normalization_factor': norm_factor,
+                            'constraint_index': slack_idx
+                        }
+        
     else:
         weights = {key: np.nan for key in ids}
         obj_val = np.nan
+        relaxed_constraints = {}
 
     optimization.results = {
         'weights': weights,
         'objective': obj_val,
-        'status': status
+        'status': status,
+        'relaxed_constraints': relaxed_constraints
     }
     optimization.model.dispose()
     return True
@@ -109,6 +153,7 @@ def model_gurobi(optimization) -> None:
     GhAb = optimization.constraints.to_GhAb()
     N = len(optimization.constraints.selection)
     transaction_cost = optimization.params.get('transaction_cost')
+    slack_penalty = optimization.params.get('slack_penalty', 1e6)
 
     # Initialize Gurobi model
     optimization.model = Model('portfolio')
@@ -121,6 +166,19 @@ def model_gurobi(optimization) -> None:
     v_type = GRB.CONTINUOUS
     x = optimization.model.addMVar(N, lb = lb, ub = ub, vtype = v_type, name = 'x')
 
+    # Store soft constraint information for later use in solve_gurobi
+    optimization.soft_indices = GhAb.get('soft_indices', [])
+    optimization.normalization_factors = GhAb.get('normalization_factors', [])
+
+    # Add slack variables to the model for soft constraints
+    num_slack = len(optimization.soft_indices)
+    if num_slack > 0:
+        slack = optimization.model.addMVar(num_slack, lb = np.zeros(num_slack), name = 'slack')
+        optimization.slack_var = slack  # Store for later retrieval
+    else:
+        slack = None
+        optimization.slack_var = None
+
     # Objective function
     if transaction_cost is not None:
         # Auxiliary variables to deal with the abs() function
@@ -131,12 +189,28 @@ def model_gurobi(optimization) -> None:
         obj_fun = q.T @ x + 0.5 * (x @ P @ x) + transaction_cost * aux_turnover.sum()
     else:
         obj_fun = q.T @ x + 0.5 * (x @ P @ x)
+    
+    # Add slack penalty term to the objective function
+    if slack is not None:
+        obj_fun = obj_fun + slack_penalty * slack.sum()
 
     optimization.model.setObjective(obj_fun, GRB.MINIMIZE)
 
-    # Add linear inequality constraints
+    # Add linear inequality constraints with slack variables for soft constraints
     if GhAb['G'] is not None:
-        optimization.model.addConstr(GhAb['G'] @ x <= GhAb['h'], 'Gh')
+        if num_slack > 0:
+            # For each inequality constraint, add slack if it's soft
+            for i in range(GhAb['G'].shape[0]):
+                if i in optimization.soft_indices:
+                    # Get the index in the slack array
+                    slack_idx = optimization.soft_indices.index(i)
+                    optimization.model.addConstr(GhAb['G'][i] @ x <= GhAb['h'][i] + slack[slack_idx], f'Gh_soft_{i}')
+                else:
+                    # Add hard constraint
+                    optimization.model.addConstr(GhAb['G'][i] @ x <= GhAb['h'][i], f'Gh_hard_{i}')
+        else:
+            # No soft constraints, add all as hard constraints
+            optimization.model.addConstr(GhAb['G'] @ x <= GhAb['h'], 'Gh')
 
     # Add linear equality constraints
     if GhAb['A'] is not None:
@@ -170,7 +244,7 @@ def model_gurobi(optimization) -> None:
 # Load data (returns series)
 # --------------------------------------------------------------------------
 
-data = load_data_msci(path = '../data/', n = 10)
+data = load_data_msci(n = 10)
 data['return_series'].head()
 
 
@@ -214,8 +288,8 @@ G.iloc[1, 3:6] = 1
 G.iloc[2, 6:10] = 1
 
 h = pd.Series(
-    [0.5, 0.5, 0.5], # feasible
-    # [0.3, 0.3, 0.3], # infeasible
+    # [0.5, 0.5, 0.5], # feasible
+    [0.3, 0.3, 0.3], # infeasible
     index=G.index
 )
 soft = pd.Series(
@@ -255,11 +329,4 @@ mv.set_objective(optimization_data=data)
 
 model_gurobi(optimization=mv)  # Creates an attribute 'model' in the optimization object
 solve_gurobi(optimization=mv)  # Creates an attribute 'results' in the optimization object
-
-mv.results  # Extract the results from the optimization object
-
-
-
-
-
-
+print(mv.results)

--- a/src/constraints.py
+++ b/src/constraints.py
@@ -87,6 +87,9 @@ class Constraints:
         if isinstance(soft, bool):
             soft = pd.Series(soft, index=Amat.index)
 
+        # Enforce soft=False for equality constraints
+        soft = soft.where(sense != '=', False)
+
         if self.linear['Amat'] is not None:
             Amat = pd.concat([self.linear['Amat'], Amat], axis=0, ignore_index=False)
             sense = pd.concat([self.linear['sense'], sense], axis=0, ignore_index=False)
@@ -121,6 +124,8 @@ class Constraints:
         b = None
         G = None
         h = None
+        soft_indices = []  # Track which rows of G have soft constraints
+        normalization_factors = []  # Track normalization factors for reporting
 
         if self.budget['Amat'] is not None:
             if self.budget['sense'] == '=':
@@ -140,6 +145,7 @@ class Constraints:
         if self.linear['Amat'] is not None:
             Amat = self.linear['Amat'].copy()
             rhs = self.linear['rhs'].copy()
+            soft = self.linear['soft'].copy()
 
             # Ensure that the system of inequalities is all '<='
             idx_geq = np.array(self.linear['sense'] == '>=')
@@ -157,11 +163,27 @@ class Constraints:
                 if idx_eq.sum() < Amat.shape[0]:
                     G_tmp = Amat[idx_eq == False].to_numpy()
                     h_tmp = rhs[idx_eq == False].to_numpy()
+                    soft_tmp = soft[idx_eq == False].to_numpy()
             else:
                 G_tmp = Amat.to_numpy()
                 h_tmp = rhs.to_numpy()
+                soft_tmp = soft.to_numpy()
 
             if 'G_tmp' in locals():
+                # Normalize soft inequality constraints
+                start_idx = G.shape[0] if G is not None else 0
+                for i, is_soft in enumerate(soft_tmp):
+                    if is_soft:
+                        # Compute norm of constraint coefficients
+                        norm = np.linalg.norm(G_tmp[i])
+                        if norm > 1e-10:  # Avoid division by zero
+                            G_tmp[i] = G_tmp[i] / norm
+                            h_tmp[i] = h_tmp[i] / norm
+                            normalization_factors.append(norm)
+                        else:
+                            normalization_factors.append(1.0)
+                        soft_indices.append(start_idx + i)
+                    
                 G = np.vstack((G, G_tmp)) if G is not None else G_tmp
                 h = np.concatenate((h, h_tmp), axis=None) if h is not None else h_tmp
 
@@ -169,7 +191,7 @@ class Constraints:
         A = A.reshape(-1, A.shape[-1]) if A is not None else None
         G = G.reshape(-1, G.shape[-1]) if G is not None else None
 
-        return {'G': G, 'h': h, 'A': A, 'b': b}
+        return {'G': G, 'h': h, 'A': A, 'b': b, 'soft_indices': soft_indices, 'normalization_factors': normalization_factors}
 
 
 


### PR DESCRIPTION
Overview
This PR adds soft constraint support for linear inequality constraints in the portfolio optimization framework. Soft constraints can be violated when necessary (with a penalty), enabling solutions for otherwise infeasible problems.

Key Changes
1. `src/constraints.py`
   - `add_linear()` method:
     - Added enforcement that equality constraints cannot be soft
     - Automatically sets `soft=False` for constraints with `sense='='`
   - `to_GhAb()` method:
     - Normalizes soft inequality constraints by their L2 norm for geometrically interpretable slack values
     - Returns `soft_indices` and `normalization_factors` to track which constraints are soft and their normalization

2. `example/soft_constraints_v2.py`
   - `model_gurobi()` function:
     - Creates slack variables `s_i ≥ 0` for each soft constraint
     - Transforms `a_i^T x ≤ b_i` into `a_i^T x ≤ b_i + s_i`
     - Adds penalty term `slack_penalty * Σs_i` to the objective function
   - `solve_gurobi()` function:
     - Extracts and reports which constraints were relaxed after optimization
     - Adds `relaxed_constraints` field to results dictionary with violation details